### PR TITLE
Add sup default styles

### DIFF
--- a/_config.typography.scss
+++ b/_config.typography.scss
@@ -13,6 +13,12 @@ html {
     font-family: $font;
 }
 
+// Reset sup styles to override the reset in oleg-starter-pack
+sup {
+    font-size: smaller;
+    vertical-align: super;
+}
+
 // Font size mixins
 // You can use these mixins directly in a component or module to trigger the font size rules. Alternatively, you can use the classes to add to your HTML to trigger font sizes without needing to edit any Sass files
 @mixin fsize-12 {


### PR DESCRIPTION
**Task:** N/A. Discovered the issue while updating old Media Centre articles.

**Previews:**
- https://aptest06alpha.agepartnership.co.uk/introducers/
    - 2 sups used under Nav > Products
- https://aptest06alpha.agepartnership.co.uk/pension-income/
    - This is just an example of an unaffected sup with its own styles applied (h1 on banner)

**What I've Done:** Set styling for `<sup>`s back to default to override the reset in oleg-starter-pack

**Checks:** 
- Valid SCSS
- Non-malicious code