### PR TITLE
Feature/setup breakpoint and spacing variables

### DIFF
--- a/_all.scss
+++ b/_all.scss
@@ -1,2 +1,3 @@
+@import "config.breakpoints";
 @import "config.colour";
 @import "config.typography";

--- a/_all.scss
+++ b/_all.scss
@@ -1,3 +1,4 @@
 @import "config.breakpoints";
 @import "config.colour";
+@import "config.space";
 @import "config.typography";

--- a/_config.breakpoints.scss
+++ b/_config.breakpoints.scss
@@ -10,5 +10,5 @@ $desktop-upper: 1799px;
 $big-desktop-lower: 1800px;
 
 // These variables are used by Bulma (https://bulma.io/documentation/overview/responsiveness/)
-$tablet: $tablet-lower;
+$tablet: $tablet-portrait-lower;
 $desktop: $desktop-lower;

--- a/_config.breakpoints.scss
+++ b/_config.breakpoints.scss
@@ -1,0 +1,14 @@
+
+// These variables are used by the breakpoint mixins (mixins/_breakpoints.scss)
+$mobile-upper: 599px;
+$tablet-portrait-lower: 600px;
+$tablet-portrait-upper: 899px;
+$tablet-landscape-lower: 900px;
+$tablet-landscape-upper: 1199px;
+$desktop-lower: 1200px;
+$desktop-upper: 1799px;
+$big-desktop-lower: 1800px;
+
+// These variables are used by Bulma (https://bulma.io/documentation/overview/responsiveness/)
+$tablet: $tablet-lower;
+$desktop: $desktop-lower;

--- a/_config.space.scss
+++ b/_config.space.scss
@@ -1,0 +1,5 @@
+$space: 16px; // Default AP space variable
+
+// Bulma spacing
+
+$column-gap: $space/2;

--- a/_config.space.scss
+++ b/_config.space.scss
@@ -2,4 +2,4 @@ $space: 16px; // Default AP space variable
 
 // Bulma spacing
 
-//$column-gap: $space/2;
+$column-gap: $space/2;

--- a/_config.space.scss
+++ b/_config.space.scss
@@ -2,4 +2,4 @@ $space: 16px; // Default AP space variable
 
 // Bulma spacing
 
-$column-gap: $space/2;
+//$column-gap: $space/2;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oleg-brand-kit",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "A place to store global brand information for use across various digital properties (Sass colour variables, typography etc)",
   "main": "index.js",
   "repository": "git@github.com:AgePartnership/oleg-brand-kit.git",


### PR DESCRIPTION
Task: https://webjobs.agepartnership.co.uk/#tasks/12907739
Ticket: https://webjobs.agepartnership.co.uk/desk/#/tickets/4529787

Changes: As part of PPC CVR I have been trying to work with bulma columns but had conflicting things happening so I have variablised the [starter pack breakpoints](https://github.com/AgePartnership/oleg-starter-pack/pull/8) (with default variables). These are then set here. I have also updated the StyleGuide to explain how breakpoints work on our site.

In this PR I have also added the values for the AP space variable as well as setting the bulma column gap required

Preview: This is branch is currently installed on AgePartnership/web.agepartnership.co.uk#1421 and the preview link is - https://local.agepartnership.co.uk:4433/styleguide/components-and-modules/global/icon-checkbox-grid/?webSyncID=598de15d-0cc5-d804-9ec4-55dbb8d175bb&sessionGUID=b2e5e765-7ca8-ab09-16c2-a22c60997925

Checks: Malicious code, Oleggy