### PR TITLE
Change AP blue colours

### DIFF
--- a/config/_config.colour.scss
+++ b/config/_config.colour.scss
@@ -3,7 +3,7 @@
 $blue-6: #0C2A45;
 $blue-5: #123F68;
 $blue-4: #19558C;
-$blue-3: #5289bF;
+$blue-3: #5289BF;
 $blue-2: #96BCE3;
 $blue-1: #E3F1FF;
 

--- a/config/_config.colour.scss
+++ b/config/_config.colour.scss
@@ -3,9 +3,9 @@
 $blue-6: #0C2A45;
 $blue-5: #123F68;
 $blue-4: #19558C;
-$blue-3: #517FA8;
-$blue-2: #8CAAC5;
-$blue-1: #E9F1F9;
+$blue-3: #5289bF;
+$blue-2: #96BCE3;
+$blue-1: #E3F1FF;
 
 // Red shades
 $red-4: #891722;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oleg-brand-kit",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A place to store global brand information for use across various digital properties (Sass colour variables, typography etc)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/4914941/messages#19758169

Changes:
- Update AP blue colours

Checks:
- Non-malicious
- Colours correct as per brief https://webjobs.agepartnership.co.uk/desk/tickets/4914941/messages#19758169
- Anything missed? (is this all that needs to be done in this repo, then once this is merged npm install will need to be done in web.ap?)