### PR TITLE
add missing info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is distributed through Yarn.
 We use [`npm version`](https://docs.npmjs.com/cli/v6/commands/npm-version) with some custom commit hooks in `package.json` to handle updating our package version, creating our Git release and tag, and pushing the changes to Github. There's no need to do a `git flow release`, to manually update the package version in package.json, or to manually merge your code into master and push your tags.
 
 Here's the process for publishing your changes:
-1. Merge your approved changes into develop.
+1. Merge your approved changes into develop and pull down develop locally.
 2. Run `npm version [patch / minor / major]`, following normal [semantic versioning constraints](https://semver.org/).
 
 ## Install using npm


### PR DESCRIPTION
Ticket: https://webjobs.agepartnership.co.uk/desk/tickets/5692102/messages

Changes:
- Mention the need to pull develop in `npm version` info in readme