### PR TITLE
Include lineheight within the font mixin

### DIFF
--- a/rebuild/config/_typography.scss
+++ b/rebuild/config/_typography.scss
@@ -10,11 +10,14 @@ $regular: 400;
 $semi-bold: 500;
 $bold: 700;
 
+// Base Line Height
+$line-height: 120%;
+
 // Initialise font use on the html element
 html {
     font-family: $font--primary;
     font-size: $base-unit * 2;
-    line-height: 120%;
+    line-height: $line-height;
 }
 
 // Reset sup styles to override the reset in oleg-starter-pack
@@ -26,36 +29,45 @@ sup {
 // Font size mixins
 @mixin fsize-14 {
     font-size: 0.875rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-16 {
     font-size: 1rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-18 {
     font-size: 1.125rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-20 {
     font-size: 1.25rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-22 {
     font-size: 1.375rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-24 {
     font-size: 1.5rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-32 {
     font-size: 2rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-40 {
     font-size: 2.5rem;
+    line-height: $line-height;
 }
 
 @mixin fsize-48 {
     font-size: 3rem;
+    line-height: $line-height;
 }


### PR DESCRIPTION
Checkes required:

- Malice
- Review

Ticket/Comment: https://github.com/AgePartnership/oleg-component-library/pull/36#discussion_r1061649931 
".. update the default font size mixins to add the default 120 line height, then we can deal with overriding it on a per-component basis where necessary"
