### PR TITLE
Move page width var below breakpoints include

### DIFF
--- a/rebuild/_config.scss
+++ b/rebuild/_config.scss
@@ -1,8 +1,9 @@
 $brand-assets-dir: '../assets/' !default;
-$page-max-width: $big-desktop-lower;
 
 @import 'config/base-unit';
 @import 'config/breakpoints';
 @import 'config/colour';
 @import 'config/typography';
 @import 'config/icons';
+
+$page-max-width: $big-desktop-lower;


### PR DESCRIPTION
Task: https://webjobs.agepartnership.co.uk/app/tasks/15153575
Resolves: https://github.com/AgePartnership/oleg-brand-kit/issues/90

Changes:
- Move page width var below breakpoints include to stop gulp error

Checks:
- Non-malicious
- Sense